### PR TITLE
Fix debug increment wrap-around

### DIFF
--- a/objects/obj_card/Create_0.gml
+++ b/objects/obj_card/Create_0.gml
@@ -12,3 +12,7 @@ _debug_draw = function(){
 	obj_game._draw_card(_card_index);
 	obj_game._set_card_objects();
 }
+
+_debug_inc = function(){
+	obj_game._debug_inc(_card_index);
+}

--- a/objects/obj_game/Create_0.gml
+++ b/objects/obj_game/Create_0.gml
@@ -193,6 +193,27 @@ _draw_card = function(_arg_card){
 }
 
 // debug
+_debug_inc = function(_arg_card){
+	var _card_slot = floor(real(_arg_card));
+	var _card_count = array_length(_card);
+
+	if(_card_count <= 0)
+		return;
+
+	if(_card_slot < 0 || _card_slot >= _card_count)
+		return;
+
+	var _value = _card[_card_slot];
+
+	if(!is_real(_value) || _value < 0)
+		_value = 0;
+	else
+		_value = (_value + 1) mod 52;
+
+	_card[_card_slot] = _value;
+	_set_card_objects();
+}
+
 _debug_rng = function(){
 	_draw_hand();
 	_set_card_objects();


### PR DESCRIPTION
## Summary
- add a debug increment routine that wraps card values back to the start of the deck
- expose the card-level helper so individual cards can trigger the wrapped increment

## Testing
- not run (GameMaker project)


------
https://chatgpt.com/codex/tasks/task_e_68e5932cf6788325b4f7a3cf7e74d611